### PR TITLE
[Refactor] #39 유저 인증/인가 재구성

### DIFF
--- a/src/main/java/hanium/where2go/domain/user/adapter/UserAdapter.java
+++ b/src/main/java/hanium/where2go/domain/user/adapter/UserAdapter.java
@@ -12,7 +12,7 @@ public class UserAdapter extends org.springframework.security.core.userdetails.U
     private User user;
 
     public UserAdapter(User user) {
-        super(user.getEmail(), user.getPassword(), Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+        super(user.getEmail(), user.getPassword(), Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())));
         this.user = user;
     }
 

--- a/src/main/java/hanium/where2go/domain/user/entity/Role.java
+++ b/src/main/java/hanium/where2go/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package hanium.where2go.domain.user.entity;
+
+public enum Role {
+    GUEST, CUSTOMER, OWNER;
+}

--- a/src/main/java/hanium/where2go/domain/user/entity/User.java
+++ b/src/main/java/hanium/where2go/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package hanium.where2go.domain.user.entity;
 import hanium.where2go.domain.user.dto.UserInfoRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -21,7 +22,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name = "role")
 public abstract class User {
 
     @Id
@@ -35,6 +35,11 @@ public abstract class User {
     private String phoneNumber;
     private String nickname;
     private boolean isVerified;
+
+    //기본 유저 생성시 GUEST로 초기화
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.GUEST;
 
     @CreatedDate
     @Column(updatable = false, nullable = false)

--- a/src/main/java/hanium/where2go/domain/user/repository/UserRepository.java
+++ b/src/main/java/hanium/where2go/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package hanium.where2go.domain.user.repository;
+
+import hanium.where2go.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/hanium/where2go/domain/user/service/UserDetailServiceImpl.java
+++ b/src/main/java/hanium/where2go/domain/user/service/UserDetailServiceImpl.java
@@ -1,8 +1,8 @@
-package hanium.where2go.domain.customer.service;
+package hanium.where2go.domain.user.service;
 
-import hanium.where2go.domain.customer.entity.Customer;
-import hanium.where2go.domain.customer.repository.CustomerRepository;
 import hanium.where2go.domain.user.adapter.UserAdapter;
+import hanium.where2go.domain.user.entity.User;
+import hanium.where2go.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -11,15 +11,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class CustomerDetailServiceImpl implements UserDetailsService {
+public class UserDetailServiceImpl implements UserDetailsService {
 
-    private final CustomerRepository customerRepository;
+    private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Customer customer = customerRepository.findByEmail(email)
+        User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("user not found"));
 
-        return new UserAdapter(customer);
+        return new UserAdapter(user);
     }
 }

--- a/src/main/java/hanium/where2go/global/jwt/JwtProvider.java
+++ b/src/main/java/hanium/where2go/global/jwt/JwtProvider.java
@@ -1,6 +1,6 @@
 package hanium.where2go.global.jwt;
 
-import hanium.where2go.domain.customer.service.CustomerDetailServiceImpl;
+import hanium.where2go.domain.user.service.UserDetailServiceImpl;
 import hanium.where2go.global.response.BaseException;
 import hanium.where2go.global.response.ExceptionCode;
 import io.jsonwebtoken.Claims;
@@ -8,9 +8,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SecurityException;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,7 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
@@ -30,16 +27,16 @@ public class JwtProvider {
     private final Key secretKey;
     private final Long accessTokenExpireTime;
     private final Long refreshTokenExpireTime;
-    private final CustomerDetailServiceImpl customerDetailService;
+    private final UserDetailServiceImpl userDetailService;
 
     public JwtProvider(@Value("${jwt.secretKey}") String secretKey,
                        @Value("${jwt.access.expire-time}") Long accessTokenExpireTime,
                        @Value("${jwt.refresh.expire-time}") Long refreshTokenExpireTime,
-                        CustomerDetailServiceImpl customerDetailService) {
+                       UserDetailServiceImpl userDetailService) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpireTime = accessTokenExpireTime;
         this.refreshTokenExpireTime = refreshTokenExpireTime;
-        this.customerDetailService = customerDetailService;
+        this.userDetailService = userDetailService;
     }
 
     //이메일을 바탕으로 AccessToken 생성
@@ -104,7 +101,7 @@ public class JwtProvider {
     //Access token으로 부터 Authentication 객체 생성
     public Authentication getAuthenticationByAccessToken(String accessToken) {
         String email = extractEmail(accessToken);
-        UserDetails userDetails = customerDetailService.loadUserByUsername(email);
+        UserDetails userDetails = userDetailService.loadUserByUsername(email);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }


### PR DESCRIPTION
유저 인증/인가 재구성

- 인증/인가 -> UserRepository/UserDetailServiceImpl로 구현하여 사용
- 그외 -> 사용자별 Repository 각각 구현(CustomerRepostiory, OwnerRepository)하여 사용
- @AuthUser Customer customer, @AuthUser Owner owner 로 사용
- User @DiscrimatorColumn 제거 후 Role 필드 추가
- 회원가입시 기본 GUSET, 이메일 인증 완료시 GUEST->CUSTOMER or OWNER로 변경 후 권한체크하기
- 현재 Authorize 과정에서 권한 없어도 403 에러 던짐 ( 추후 해결...)

close #39 
