### PR TITLE
[Feat] #54 선호 업종, 주종 CURD ,  #55 OSIV on

### DIFF
--- a/src/main/java/hanium/where2go/domain/category/dto/CategoryDto.java
+++ b/src/main/java/hanium/where2go/domain/category/dto/CategoryDto.java
@@ -1,11 +1,15 @@
 package hanium.where2go.domain.category.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CategoryDto {
 
     private Long categoryId;

--- a/src/main/java/hanium/where2go/domain/customer/controller/CustomerController.java
+++ b/src/main/java/hanium/where2go/domain/customer/controller/CustomerController.java
@@ -47,17 +47,17 @@ public class CustomerController {
         return new BaseResponse<>(200, "사용자 아이디를 가져왔습니다.", customerService.findEmail(customerFindEmailRequestDto));
     }
 
-    @GetMapping("/{customerId}/info")
-    public ResponseEntity<BaseResponse<CustomerInfoResponseDto>> getCustomerInfo(@AuthUser Customer customer, @PathVariable Long customerId) {
-        CustomerInfoResponseDto info = customerService.getInfo(customer, customerId);
+    @GetMapping("/info")
+    public ResponseEntity<BaseResponse<CustomerInfoResponseDto>> getCustomerInfo(@AuthUser Customer customer) {
+        CustomerInfoResponseDto info = customerService.getInfo(customer);
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 정보를 가져왔습니다.", info));
     }
 
-    @PatchMapping("/{customerId}/info")
-    public ResponseEntity<BaseResponse<CustomerInfoResponseDto>> updateCustomerInfo(@AuthUser Customer customer, @PathVariable Long customerId, @RequestBody UserInfoRequestDto userInfoRequestDto) {
-        CustomerInfoResponseDto info = customerService.updateInfo(customer, customerId, userInfoRequestDto);
+    @PatchMapping("/info")
+    public ResponseEntity<BaseResponse<CustomerInfoResponseDto>> updateCustomerInfo(@AuthUser Customer customer, @RequestBody UserInfoRequestDto userInfoRequestDto) {
+        CustomerInfoResponseDto info = customerService.updateInfo(customer, userInfoRequestDto);
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 정보를 업데이트 했습니다.", info));
@@ -77,4 +77,51 @@ public class CustomerController {
             .status(HttpStatus.OK)
             .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 포인트를 가져왔습니다.", customerService.getPoint(customer)));
     }
+
+    @PostMapping("/favor-liquors")
+    public ResponseEntity<BaseResponse<String>> postFavorLiquor(@AuthUser Customer customer, @RequestBody CustomerFavorLiquorRequestDto customerFavorLiquorRequestDto) {
+        customerService.createFavorLiquor(customer, customerFavorLiquorRequestDto.getLiquorId());
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 주종을 추가했습니다.", null));
+    }
+
+    @GetMapping("/favor-liquors")
+    public ResponseEntity<BaseResponse<CustomerFavorLiquorResponseDto>> getFavorLiquors(@AuthUser Customer customer) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 주종을 가져왔습니다.", customerService.getFavorLiquors(customer)));
+    }
+
+    @DeleteMapping("/favor-liquors/{liquorId}")
+    public ResponseEntity<BaseResponse<String>> deleteFavorLiquor(@AuthUser Customer customer, @PathVariable Long liquorId) {
+        customerService.deleteFavorLiquor(customer, liquorId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 주종을 삭제했습니다.", null));
+    }
+
+    @PostMapping("/favor-categories")
+    public ResponseEntity<BaseResponse<String>> postFavorCategory(@AuthUser Customer customer, @RequestBody CustomerFavorCategoryRequestDto customerFavorCategoryRequestDto) {
+        customerService.createFavorCategory(customer, customerFavorCategoryRequestDto.getCategoryId());
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 업종을 추가했습니다.", null));
+    }
+
+    @GetMapping("/favor-categories")
+    public ResponseEntity<BaseResponse<CustomerFavorLiquorResponseDto>> getFavorCategories(@AuthUser Customer customer) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 업종을 가져왔습니다.", customerService.getFavorCategories(customer)));
+    }
+
+    @DeleteMapping("/favor-categories/{categoryId}")
+    public ResponseEntity<BaseResponse<String>> deleteFavorCategory(@AuthUser Customer customer, @PathVariable Long categoryId) {
+        customerService.deleteFavorCategory(customer, categoryId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(new BaseResponse<>(HttpStatus.OK.value(), "사용자 선호 업종을 삭제했습니다.", null));
+    }
+
 }

--- a/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorCategoryRequestDto.java
+++ b/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorCategoryRequestDto.java
@@ -1,0 +1,15 @@
+package hanium.where2go.domain.customer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerFavorCategoryRequestDto {
+
+    private Long categoryId;
+}

--- a/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorCategoryResponseDto.java
+++ b/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorCategoryResponseDto.java
@@ -1,0 +1,17 @@
+package hanium.where2go.domain.customer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerFavorCategoryResponseDto {
+
+    private List<Long> favorCategories;
+}

--- a/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorLiquorRequestDto.java
+++ b/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorLiquorRequestDto.java
@@ -1,0 +1,15 @@
+package hanium.where2go.domain.customer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerFavorLiquorRequestDto {
+
+    private Long liquorId;
+}

--- a/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorLiquorResponseDto.java
+++ b/src/main/java/hanium/where2go/domain/customer/dto/CustomerFavorLiquorResponseDto.java
@@ -1,0 +1,17 @@
+package hanium.where2go.domain.customer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerFavorLiquorResponseDto {
+
+    private List<Long> favorLiquors;
+}

--- a/src/main/java/hanium/where2go/domain/customer/entity/Customer.java
+++ b/src/main/java/hanium/where2go/domain/customer/entity/Customer.java
@@ -38,6 +38,7 @@ public class Customer extends User {
         point.setCustomer(this);
     }
 
+    // 포인트 적립, 사용, 충전
     public void earn(int amount, String description) {
         point.earn(amount);
 
@@ -75,5 +76,25 @@ public class Customer extends User {
             .build();
 
         this.transactions.add(transaction);
+    }
+
+    //선호 주종
+    public void addFavorLiquor(FavorLiquor favorLiquor) {
+        favorLiquor.setCustomer(this);
+        favorLiquors.add(favorLiquor);
+    }
+
+    public void removeFavorLiquor(FavorLiquor favorLiquor) {
+        favorLiquor.setCustomer(null);
+    }
+
+    //선호 업종
+    public void addFavorCategory(FavorCategory favorCategory) {
+        favorCategory.setCustomer(this);
+        favorCategories.add(favorCategory);
+    }
+
+    public void removeFavorCategory(FavorCategory favorCategory) {
+        favorCategory.setCustomer(null);
     }
 }

--- a/src/main/java/hanium/where2go/domain/customer/entity/FavorCategory.java
+++ b/src/main/java/hanium/where2go/domain/customer/entity/FavorCategory.java
@@ -29,4 +29,8 @@ public class FavorCategory extends BaseEntity {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
+    }
+
 }

--- a/src/main/java/hanium/where2go/domain/customer/entity/FavorLiquor.java
+++ b/src/main/java/hanium/where2go/domain/customer/entity/FavorLiquor.java
@@ -29,4 +29,8 @@ public class FavorLiquor extends BaseEntity {
     @JoinColumn(name = "liquor_id")
     private Liquor liquor;
 
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
+    }
+
 }

--- a/src/main/java/hanium/where2go/domain/liquor/dto/LiquorDto.java
+++ b/src/main/java/hanium/where2go/domain/liquor/dto/LiquorDto.java
@@ -1,11 +1,15 @@
 package hanium.where2go.domain.liquor.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class LiquorDto {
 
     private Long liquorId;

--- a/src/main/java/hanium/where2go/global/config/OpenEntityManagerConfig.java
+++ b/src/main/java/hanium/where2go/global/config/OpenEntityManagerConfig.java
@@ -1,0 +1,19 @@
+package hanium.where2go.global.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Configuration
+public class OpenEntityManagerConfig {
+    @Bean
+    public FilterRegistrationBean<OpenEntityManagerInViewFilter> openEntityManagerInViewFilter() {
+        FilterRegistrationBean<OpenEntityManagerInViewFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        filterFilterRegistrationBean.setFilter(new OpenEntityManagerInViewFilter());
+        filterFilterRegistrationBean.setOrder(Integer.MIN_VALUE); // 예시를 위해 최우선 순위로 Filter 등록
+        return filterFilterRegistrationBean;
+    }
+}

--- a/src/main/java/hanium/where2go/global/response/ExceptionCode.java
+++ b/src/main/java/hanium/where2go/global/response/ExceptionCode.java
@@ -17,7 +17,9 @@ public enum ExceptionCode {
     LIQUOR_NOT_FOUND(404, "Liquor does not found."),
     EVENT_NOT_FOUND(404,"Event does not found"),
     RESERVATION_NOT_FOUND(404,"Reservation does not found"),
-    POINT_NOT_ENOUGH(409, "Not enough point");
+    POINT_NOT_ENOUGH(409, "Not enough point"),
+    DUPLICATED_FAVOR_CATEGORY(400,"Favor Category already exists."),
+    DUPLICATED_FAVOR_LIQUOR(400,"Favor Category already exists.");
 
     private int status;
     private String message;


### PR DESCRIPTION
#54 선호 업종, 선호 주종 CRUD
- 선호 업종 선호 주종 구현(로직 좀 자세히 리뷰해주시면 감사하게씁니다.)
- 선호 지역은 논의 필요함
- 선호하는 것의 경우 프론트에서 저장하면 조금더 깔끔한 로직이 나올것 같음.

#55 OSIV on
- @AuthUser(@AuthenticationPrincipal)을 사용시 lazy loading을 적용한 엔티티는 불러오지 못하는 경우가 있음
- 영속성 컨텍스트가 기존 OFF로 되어있어 Service단에서만 살아 있기 때문에 filter에서 적용할 경우 적용이 안되기 때문
- 따라서 OSIV를 ON하여 filter단까지 살아 있도록 수정함 
-  데이터베이스 커넥션 리소스를 낭비한다는 단점이 있지만 fetch 조인등으로 해결하기엔 userDetailsService에서 조건에 따라 맞는 쿼리문을 실행하는것이 어려움이 있다고 생각되어 이러한 방법을 선택함.
- [@AuthenticationPrincipal 유저 객체와 JPA 변경감지](https://velog.io/@shwncho/Spring-Security-AuthenticationPrincipal-%EC%9C%A0%EC%A0%80-%EC%A0%95%EB%B3%B4%EC%99%80-JPA-%EB%B3%80%EA%B2%BD%EA%B0%90%EC%A7%80)

![스크린샷 2023-08-07 오후 11 14 52](https://github.com/hanium-where2go/where2go-backend/assets/65287117/b3c2e76e-4c31-47fe-8ec7-bb142ab3e8e4)

close #54 
close #55 


